### PR TITLE
Make hourly forecasts optional

### DIFF
--- a/lib/homeassistant/_forecast.py
+++ b/lib/homeassistant/_forecast.py
@@ -53,10 +53,14 @@ class _HomeAssistantFutureForecast:
 
 @dataclass
 class HomeAssistantCurrentForecast(_HomeAssistantForecastCommon, HomeAssistantForecastMeta):
+    condition: HomeAssistantWeatherCondition
     dew_point: float
     cloud_coverage: float
     pressure: float
     uv_index: float
+
+    def __post_init__(self):
+        self.condition = HomeAssistantWeatherCondition(self.condition)
 
 
 @dataclass

--- a/lib/kodi/_adapter.py
+++ b/lib/kodi/_adapter.py
@@ -93,6 +93,8 @@ class KodiWeatherPluginAdapter:
 
     @staticmethod
     def format_unit(unit: Union[Temperature, Speed], value_format: str = "{:.0f}") -> str:
+        if unit is None or unit.value is None:
+            return ""
         return (value_format + " {}").format(unit.value, unit.unit)
 
     def set_weather_properties(self, forecast: KodiForecastData) -> None:
@@ -107,10 +109,10 @@ class KodiWeatherPluginAdapter:
         )
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.TEMPERATURE,
-            value=KodiWeatherPluginAdapter.format_unit(
+            value=self.format_unit(
                 TemperatureCelsius.from_si_value(forecast.Current.temperature.si_value())
-            )   # converted by Kodi from °C
-        )
+            ) if forecast.Current.temperature.value is not None else ""
+        )   # converted by Kodi from °C
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.UV_INDEX,
             value=str(forecast.Current.uv_index)
@@ -125,39 +127,39 @@ class KodiWeatherPluginAdapter:
         )
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.WIND,
-            value=KodiWeatherPluginAdapter.format_unit(
+            value=self.format_unit(
                 SpeedKph.from_si_value(forecast.Current.wind_speed.si_value())
-            )   # converted by Kodi from km/h
-        )
+            ) if forecast.Current.wind_speed.value is not None else ""
+        )   # converted by Kodi from km/h
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.WIND_DIRECTION,
             value=self._get_localized_string(string_id=forecast.Current.wind_direction.value)
         )
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.HUMIDITY,
-            value=str(forecast.Current.humidity)    # % is added by Kodi
-        )
+            value=str(forecast.Current.humidity) if forecast.Current.humidity is not None else ""
+        )    # % is added by Kodi
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.DEW_POINT,
-            value=KodiWeatherPluginAdapter.format_unit(
+            value=self.format_unit(
                 TemperatureCelsius.from_si_value(forecast.Current.dew_point.si_value())
-            )     # converted by Kodi from °C
-        )
+            ) if forecast.Current.dew_point.value is not None else ""
+        )     # converted by Kodi from °C
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.FEELS_LIKE,
-            value=KodiWeatherPluginAdapter.format_unit(
+            value=self.format_unit(
                 TemperatureCelsius.from_si_value(forecast.Current.feels_like.si_value())
-            )   # converted by Kodi from °C
-        )
+            ) if forecast.Current.feels_like.value is not None else ""
+        )   # converted by Kodi from °C
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.WIND_CHILL,
-            value=KodiWeatherPluginAdapter.format_unit(
+            value=self.format_unit(
                 self.temperature_unit.from_si_value(forecast.Current.feels_like.si_value())
-            )
+            ) if forecast.Current.feels_like.value is not None else ""
         )
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.PRECIPITATION,
-            value=forecast.Current.precipitation
+            value=forecast.Current.precipitation or ""
         )
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.CLOUDINESS,
@@ -165,7 +167,7 @@ class KodiWeatherPluginAdapter:
         )
         self._set_window_property(
             key=_KodiWeatherProperties.CURRENT.PRESSURE,
-            value=forecast.Current.pressure
+            value=forecast.Current.pressure or ""
         )
         self._set_window_property(
             key=_KodiWeatherProperties.GENERAL.SUNRISE,
@@ -209,9 +211,9 @@ class KodiWeatherPluginAdapter:
             )
             self._set_window_property(
                 key=hourly_properties.WIND_SPEED,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     self.wind_speed_unit.from_si_value(hourly_forecast.wind_speed.si_value())
-                )
+                ) if hourly_forecast.wind_speed.value is not None else ""
             )
             self._set_window_property(
                 key=hourly_properties.WIND_DIRECTION,
@@ -219,33 +221,33 @@ class KodiWeatherPluginAdapter:
             )
             self._set_window_property(
                 key=hourly_properties.HUMIDITY,
-                value=percent(hourly_forecast.humidity)
+                value=percent(hourly_forecast.humidity) if hourly_forecast.humidity is not None else ""
             )
             self._set_window_property(
                 key=hourly_properties.TEMPERATURE,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     self.temperature_unit.from_si_value(hourly_forecast.temperature.si_value())
-                )
+                ) if hourly_forecast.temperature.value is not None else ""
             )
             self._set_window_property(
                 key=hourly_properties.DEW_POINT,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     self.temperature_unit.from_si_value(hourly_forecast.dew_point.si_value())
-                )
+                ) if hourly_forecast.dew_point.value is not None else ""
             )
             self._set_window_property(
                 key=hourly_properties.FEELS_LIKE,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     self.temperature_unit.from_si_value(hourly_forecast.feels_like.si_value())
-                )
+                ) if hourly_forecast.feels_like.value is not None else ""
             )
             self._set_window_property(
                 key=hourly_properties.PRESSURE,
-                value=hourly_forecast.pressure
+                value=hourly_forecast.pressure or ""
             )
             self._set_window_property(
                 key=hourly_properties.PRECIPITATION,
-                value=hourly_forecast.precipitation
+                value=hourly_forecast.precipitation or ""
             )
 
         # daily
@@ -268,15 +270,15 @@ class KodiWeatherPluginAdapter:
             )
             self._set_window_property(
                 key=daily_properties.HIGH_TEMPERATURE,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     self.temperature_unit.from_si_value(daily_forecast.temperature.si_value())
-                )
+                ) if daily_forecast.temperature.value is not None else ""
             )
             self._set_window_property(
                 key=daily_properties.LOW_TEMPERATURE,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     self.temperature_unit.from_si_value(daily_forecast.low_temperature.si_value())
-                )
+                ) if daily_forecast.low_temperature.value is not None else ""
             )
             self._set_window_property(
                 key=daily_properties.OUTLOOK,
@@ -292,9 +294,9 @@ class KodiWeatherPluginAdapter:
             )
             self._set_window_property(
                 key=daily_properties.WIND_SPEED,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     self.wind_speed_unit.from_si_value(daily_forecast.wind_speed.si_value())
-                )
+                ) if daily_forecast.wind_speed.value is not None else ""
             )
             self._set_window_property(
                 key=daily_properties.WIND_DIRECTION,
@@ -302,7 +304,7 @@ class KodiWeatherPluginAdapter:
             )
             self._set_window_property(
                 key=daily_properties.PRECIPITATION,
-                value=daily_forecast.precipitation
+                value=daily_forecast.precipitation or ""
             )
             self._set_window_property(
                 key=daily_properties_compat.TITLE,
@@ -311,16 +313,16 @@ class KodiWeatherPluginAdapter:
             )
             self._set_window_property(
                 key=daily_properties_compat.HIGH_TEMP,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     TemperatureCelsius.from_si_value(daily_forecast.temperature.si_value())
-                )   # converted by skins from °C
-            )
+                ) if daily_forecast.temperature.value is not None else ""
+            )   # converted by skins from °C
             self._set_window_property(
                 key=daily_properties_compat.LOW_TEMP,
-                value=KodiWeatherPluginAdapter.format_unit(
+                value=self.format_unit(
                     TemperatureCelsius.from_si_value(daily_forecast.low_temperature.si_value())
-                )   # converted by skins from °C
-            )
+                ) if daily_forecast.low_temperature.value is not None else ""
+            )   # converted by skins from °C
             self._set_window_property(
                 key=daily_properties_compat.OUTLOOK,
                 value=daily_forecast.condition_str

--- a/lib/kodi/_forecast.py
+++ b/lib/kodi/_forecast.py
@@ -83,6 +83,8 @@ class KodiWindDirectionCode(IntEnum):
 
     @staticmethod
     def from_bearing(bearing: float):
+        if bearing is None:
+            return KodiWindDirectionCode.VAR
         if isinstance(bearing, str):
              bearing=bearing.upper()
              if bearing == 'N':
@@ -174,15 +176,15 @@ class _KodiConditionedForecastCommon:
 
     @property
     def condition_str(self) -> str:
-        return str(self.condition)
+        return str(self.condition) if self.condition is not None else ""
 
     @property
     def fanart_code(self) -> int:
-        return self.condition.value
+        return self.condition.value if self.condition is not None else 0
 
     @property
     def outlook_icon(self) -> str:
-        return f"{self.condition.value}.png"
+        return f"{self.condition.value}.png" if self.condition is not None else ""
 
 
 @dataclass

--- a/plugin/util/forecast_converter.py
+++ b/plugin/util/forecast_converter.py
@@ -71,6 +71,13 @@ class ForecastConverter:
         wind_speed = SpeedUnits[ha_forecast.current.wind_speed_unit](ha_forecast.current.wind_speed)
         sunrise = ForecastConverter.__parse_homeassistant_datetime(ha_sun_info.next_rising)
         sunset = ForecastConverter.__parse_homeassistant_datetime(ha_sun_info.next_setting)
+
+        ha_condition = ha_forecast.current.condition
+        if ha_condition is None and len(ha_forecast.hourly) > 0:
+            ha_condition = ha_forecast.hourly[0].condition
+        if ha_condition is None and len(ha_forecast.daily) > 0:
+            ha_condition = ha_forecast.daily[0].condition
+
         return KodiForecastData(
             General=KodiGeneralForecastData(
                 location=ha_forecast.current.friendly_name,
@@ -85,7 +92,7 @@ class ForecastConverter:
                     precipitation_unit=ha_forecast.current.precipitation_unit
                 ),  # conversion not implemented in Kodi
                 condition=ForecastConverter.__translate_condition(
-                    ha_condition=ha_forecast.hourly[0].condition if len(ha_forecast.hourly) > 0 else None,
+                    ha_condition=ha_condition,
                     is_night=not (sunrise.time() < datetime.now().time() < sunset.time())
                 ),
                 humidity=ha_forecast.current.humidity,


### PR DESCRIPTION
This fixes https://github.com/Eugeniusz-Gienek/kodi_weather_ha/issues/11

I had to change how the current condition was gathered. It used to be from the hourly forecast but I changed it to the current state of the entity. I wasn't sure if its possible for the state to be absent, but I created a fallback to hourly and daily to be sure.

For testing I had also created a minimal weather entity in Homeassistant and used it with the addon. I've also fixed the errors I ran into this way.
