### PR TITLE
Add missing `Long Day` property preferred by the Amber theme.

### DIFF
--- a/lib/kodi/_adapter.py
+++ b/lib/kodi/_adapter.py
@@ -266,6 +266,11 @@ class KodiWeatherPluginAdapter:
             self._set_window_property(
                 key=daily_properties.SHORT_DAY,
                 value=self._get_localized_string(
+                    string_id=daily_forecast.timestamp.isoweekday() + _KodiMagicValues.MESSAGE_OFFSET_DAY_SHORT)
+            )
+            self._set_window_property(
+                key=daily_properties.LONG_DAY,
+                value=self._get_localized_string(
                     string_id=daily_forecast.timestamp.isoweekday() + _KodiMagicValues.MESSAGE_OFFSET_DAY_LONG)
             )
             self._set_window_property(

--- a/lib/kodi/_properties.py
+++ b/lib/kodi/_properties.py
@@ -77,6 +77,7 @@ class _KodiHourlyWeatherProperties(_NestedProperties):
 class _KodiDailyWeatherProperties(_NestedProperties):
     SHORT_DATE = "ShortDate"
     SHORT_DAY = "ShortDay"
+    LONG_DAY = "LongDay"
     HIGH_TEMPERATURE = "HighTemperature"
     LOW_TEMPERATURE = "LowTemperature"
     OUTLOOK = "Outlook"


### PR DESCRIPTION
The [Amber](https://kodi.wiki/view/Add-on:Amber) theme `v3.99.02` running on Kodi `v21.2.0` on LibreELEC `v12.2.0` on `rpi4.aarch64` does not have day of the week without this change.

# Before:

<img width="1920" height="1080" alt="506923314-5f717a35-67fb-452c-9d2b-492ebc322694 small" src="https://github.com/user-attachments/assets/87bbf111-50ae-4a7c-ba9a-98e81006bf23" />

# After:

<img width="1920" height="1080" alt="506923349-4b452411-ae1a-4cdd-941c-8ea426489b7b small" src="https://github.com/user-attachments/assets/eda6a4b7-b32f-4c9c-b0d3-8dad68b1bdeb" />