### PR TITLE
Show errors as transient notifications instead of blocking dialogs.

### DIFF
--- a/lib/kodi/_adapter.py
+++ b/lib/kodi/_adapter.py
@@ -76,10 +76,11 @@ class KodiWeatherPluginAdapter:
     def required_settings_done(self) -> bool:
         raise NotImplementedError()
 
-    def dialog(self, message_id: int) -> bool:
-        return xbmcgui.Dialog().ok(
+    def notification(self, message_id: int) -> None:
+        xbmcgui.Dialog().notification(
             heading=self._kodi_addon.getAddonInfo(id=_KodiMagicValues.ADDON_INFO_NAME_ID),
-            message=self._get_localized_string(string_id=message_id)
+            message=self._get_localized_string(string_id=message_id),
+            icon=xbmcgui.NOTIFICATION_ERROR
         )
     
     def _set_window_property(self, key: str, value: str) -> None:

--- a/plugin/_plugin.py
+++ b/plugin/_plugin.py
@@ -13,7 +13,7 @@ class KodiHomeAssistantWeatherPlugin:
 
         if not self._kodi_adapter.required_settings_done():
             if not self._kodi_adapter.get_err_not_inform:
-                self._kodi_adapter.dialog(message_id=_HomeAssistantWeatherPluginStrings.SETTINGS_REQUIRED)
+                self._kodi_adapter.notification(message_id=_HomeAssistantWeatherPluginStrings.SETTINGS_REQUIRED)
             self._kodi_adapter.log("Settings for Home Assistant Weather not yet provided. Plugin will not work.")
         else:
             self.apply_forecast()
@@ -49,7 +49,7 @@ class KodiHomeAssistantWeatherPlugin:
             else:
                 message = _HomeAssistantWeatherPluginStrings.HOMEASSISTANT_UNEXPECTED_RESPONSE
             if not self._kodi_adapter.get_err_not_inform:
-                self._kodi_adapter.dialog(message_id=message)
+                self._kodi_adapter.notification(message_id=message)
             return None, None
 
     def apply_forecast(self):


### PR DESCRIPTION
Errors (missing settings, connection failures, auth problems) were shown with a modal OK dialog that blocked the UI until dismissed, preventing navigation and display sleep. The addon now shows the same messages as short, non-blocking notifications at the top of the screen, which makes the behaviour most consistent with other Kodi add-ons.

Replaced xbmcgui.Dialog().ok() with Dialog().notification() in the Kodi adapter and renamed the method from dialog() to notification() to match the new behaviour.

### BEFORE CHANGE:

<img width="1800" height="1168" alt="Screenshot 2026-02-21 at 6 28 02 PM" src="https://github.com/user-attachments/assets/4d5f49dd-c757-441f-9391-c2e04aa6ad3d" />
<img width="1800" height="1168" alt="Screenshot 2026-02-21 at 6 28 12 PM" src="https://github.com/user-attachments/assets/2e8d5c39-f555-42ef-83d4-1e585cb44b3f" />

### AFTER CHANGE:

<img width="2254" height="1132" alt="Screenshot 2026-02-21 at 6 29 00 PM" src="https://github.com/user-attachments/assets/50d5df05-7e55-4b37-b3ff-90f244e171cc" />
